### PR TITLE
Add array and ArrayObject support for Input attribute

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(composer install:*)",
       "Bash(composer:*)",
       "Bash(./vendor/bin/phpunit:*)",
-      "Bash(./vendor/bin/phpmd:*)"
+      "Bash(./vendor/bin/phpmd:*)",
+      "Bash(vendor/bin/phpunit:*)",
+      "Bash(XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text --coverage-filter src/)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(composer test:*)",
       "Bash(composer install:*)",
-      "Bash(composer:*)"
+      "Bash(composer:*)",
+      "Bash(./vendor/bin/phpunit:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(composer test:*)",
       "Bash(composer install:*)",
       "Bash(composer:*)",
-      "Bash(./vendor/bin/phpunit:*)"
+      "Bash(./vendor/bin/phpunit:*)",
+      "Bash(./vendor/bin/phpmd:*)"
     ],
     "deny": []
   }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,74 @@ echo $todo->title;           // Buy milk
 echo $todo->assignee->name;  // John
 ```
 
+### Array Support
+
+Ray.InputQuery supports arrays and ArrayObject collections with the `item` parameter:
+
+```php
+use Ray\InputQuery\Attribute\Input;
+
+final class UserInput
+{
+    public function __construct(
+        #[Input] public readonly string $id,
+        #[Input] public readonly string $name
+    ) {}
+}
+
+final class UserListController
+{
+    public function updateUsers(
+        #[Input(item: UserInput::class)] array $users  // Array of UserInput objects
+    ) {
+        foreach ($users as $user) {
+            echo $user->name; // Each element is a UserInput instance
+        }
+    }
+    
+    public function processUsers(
+        #[Input(item: UserInput::class)] ArrayObject $users  // ArrayObject collection
+    ) {
+        // $users is an ArrayObject containing UserInput instances
+    }
+}
+```
+
+Query data format for arrays:
+
+```php
+$data = [
+    'users' => [
+        ['id' => '1', 'name' => 'John'],
+        ['id' => '2', 'name' => 'Jane'],
+        ['id' => '3', 'name' => 'Bob']
+    ]
+];
+
+$args = $inputQuery->getArguments($method, $data);
+// $args[0] will be an array of UserInput objects
+```
+
+**ArrayObject Inheritance Support:**
+
+Custom ArrayObject subclasses are also supported:
+
+```php
+final class UserCollection extends ArrayObject
+{
+    public function getFirst(): ?UserInput
+    {
+        return $this[0] ?? null;
+    }
+}
+
+public function handleUsers(
+    #[Input(item: UserInput::class)] UserCollection $users
+) {
+    $firstUser = $users->getFirst(); // Custom method available
+}
+```
+
 ### Mixed with Dependency Injection
 
 Parameters without the `#[Input]` attribute are resolved via dependency injection:

--- a/demo/ArrayDemo.php
+++ b/demo/ArrayDemo.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Ray\Di\Injector;
+use Ray\InputQuery\Attribute\Input;
+use Ray\InputQuery\InputQuery;
+
+// User input class
+final class User
+{
+    public function __construct(
+        #[Input]
+        public readonly string $id,
+        #[Input]
+        public readonly string $name
+    ) {
+    }
+}
+
+// Controller with array handling
+final class UserController
+{
+    public function listUsers(
+        #[Input(item: User::class)]
+        array $users
+    ): void {
+        echo "Array of users:\n";
+        foreach ($users as $index => $user) {
+            echo "  [$index] ID: {$user->id}, Name: {$user->name}\n";
+        }
+    }
+    
+    public function listUsersAsArrayObject(
+        #[Input(item: User::class)]
+        ArrayObject $users
+    ): void {
+        echo "\nArrayObject of users:\n";
+        foreach ($users as $index => $user) {
+            echo "  [$index] ID: {$user->id}, Name: {$user->name}\n";
+        }
+    }
+}
+
+// Demo
+$injector = new Injector();
+$inputQuery = new InputQuery($injector);
+
+// Sample query data (like from $_POST)
+$query = [
+    'users' => [
+        ['id' => '1', 'name' => 'jingu'],
+        ['id' => '2', 'name' => 'horikawa'],
+        ['id' => '3', 'name' => 'tanaka']
+    ]
+];
+
+$controller = new UserController();
+
+// Array example
+$method = new ReflectionMethod($controller, 'listUsers');
+$args = $inputQuery->getArguments($method, $query);
+$controller->listUsers(...$args);
+
+// ArrayObject example
+$method = new ReflectionMethod($controller, 'listUsersAsArrayObject');
+$args = $inputQuery->getArguments($method, $query);
+$controller->listUsersAsArrayObject(...$args);

--- a/src/Attribute/Input.php
+++ b/src/Attribute/Input.php
@@ -9,4 +9,8 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final class Input
 {
+    public function __construct(
+        public readonly string|null $item = null,
+    ) {
+    }
 }

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\InputQuery;
 
+use ArrayObject;
 use InvalidArgumentException;
 use Override;
 use Ray\Di\Di\Named;
@@ -18,6 +19,7 @@ use ReflectionParameter;
 
 use function assert;
 use function class_exists;
+use function is_array;
 use function is_bool;
 use function is_float;
 use function is_int;
@@ -100,11 +102,30 @@ final class InputQuery implements InputQueryInterface
         }
 
         if ($type->isBuiltin()) {
+            // Check if it's an array type with item specification
+            if ($type->getName() === 'array') {
+                $inputAttribute = $inputAttributes[0]->newInstance();
+                if ($inputAttribute->item !== null) {
+                    return $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+                }
+            }
+
             // Scalar type with #[Input]
             /** @psalm-suppress MixedAssignment $value */
+
             $value = $query[$paramName] ?? $this->getDefaultValue($param);
 
             return $this->convertScalar($value, $type);
+        }
+
+        // Check if it's ArrayObject with item specification
+        if ($type->getName() === 'ArrayObject') {
+            $inputAttribute = $inputAttributes[0]->newInstance();
+            if ($inputAttribute->item !== null) {
+                $array = $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+
+                return new ArrayObject($array);
+            }
         }
 
         // Object type with #[Input] - create nested
@@ -244,5 +265,29 @@ final class InputQuery implements InputQueryInterface
         $string = str_replace(' ', '', $string);
 
         return lcfirst($string);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param class-string         $itemClass
+     *
+     * @return array<mixed>
+     */
+    private function createArrayOfInputs(string $paramName, array $query, string $itemClass): array
+    {
+        $arrayData = $query[$paramName] ?? [];
+
+        if (! is_array($arrayData)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($arrayData as $key => $itemData) {
+            if (is_array($itemData)) {
+                $result[$key] = $this->create($itemClass, $itemData);
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -17,6 +17,7 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 
+use function array_key_exists;
 use function assert;
 use function class_exists;
 use function is_array;
@@ -107,7 +108,11 @@ final class InputQuery implements InputQueryInterface
             if ($type->getName() === 'array') {
                 $inputAttribute = $inputAttributes[0]->newInstance();
                 if ($inputAttribute->item !== null) {
-                    return $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+                    assert(class_exists($inputAttribute->item));
+                    $itemClass = $inputAttribute->item;
+
+                    /** @var class-string<T> $itemClass */
+                    return $this->createArrayOfInputs($paramName, $query, $itemClass);
                 }
             }
 
@@ -124,7 +129,10 @@ final class InputQuery implements InputQueryInterface
         if (class_exists($className) && is_subclass_of($className, ArrayObject::class)) {
             $inputAttribute = $inputAttributes[0]->newInstance();
             if ($inputAttribute->item !== null) {
-                $array = $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+                assert(class_exists($inputAttribute->item));
+                /** @var class-string<T> $itemClass */
+                $itemClass = $inputAttribute->item;
+                $array = $this->createArrayOfInputs($paramName, $query, $itemClass);
                 $reflectionClass = new ReflectionClass($className);
 
                 return $reflectionClass->newInstance($array);
@@ -135,7 +143,10 @@ final class InputQuery implements InputQueryInterface
         if ($className === ArrayObject::class) {
             $inputAttribute = $inputAttributes[0]->newInstance();
             if ($inputAttribute->item !== null) {
-                $array = $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+                assert(class_exists($inputAttribute->item));
+                /** @var class-string<T> $itemClass */
+                $itemClass = $inputAttribute->item;
+                $array = $this->createArrayOfInputs($paramName, $query, $itemClass);
 
                 return new ArrayObject($array);
             }
@@ -282,21 +293,30 @@ final class InputQuery implements InputQueryInterface
 
     /**
      * @param array<string, mixed> $query
-     * @param class-string         $itemClass
+     * @param class-string<T>      $itemClass
      *
      * @return array<mixed>
      */
     private function createArrayOfInputs(string $paramName, array $query, string $itemClass): array
     {
-        $arrayData = $query[$paramName] ?? [];
+        if (! array_key_exists($paramName, $query)) {
+            return [];
+        }
+
+        /** @var mixed $arrayData */
+        $arrayData = $query[$paramName];
 
         if (! is_array($arrayData)) {
             return [];
         }
 
         $result = [];
+        /** @var mixed $itemData */
         foreach ($arrayData as $key => $itemData) {
             if (is_array($itemData)) {
+                // Query parameters from HTTP requests have string keys
+                /** @psalm-var array<string, mixed> $itemData */
+                /** @phpstan-var array<string, mixed> $itemData */
                 $result[$key] = $this->create($itemClass, $itemData);
             }
         }

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -12,6 +12,7 @@ use Ray\Di\Di\Qualifier;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
 use Ray\InputQuery\Attribute\Input;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -99,8 +100,8 @@ final class InputQuery implements InputQueryInterface
     }
 
     /**
-     * @param array<string, mixed> $query
-     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     * @param array<string, mixed>              $query
+     * @param array<ReflectionAttribute<Input>> $inputAttributes
      */
     private function resolveInputParameter(ReflectionParameter $param, array $query, array $inputAttributes): mixed
     {
@@ -119,8 +120,8 @@ final class InputQuery implements InputQueryInterface
     }
 
     /**
-     * @param array<string, mixed> $query
-     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     * @param array<string, mixed>              $query
+     * @param array<ReflectionAttribute<Input>> $inputAttributes
      */
     private function resolveBuiltinType(ReflectionParameter $param, array $query, array $inputAttributes, ReflectionNamedType $type): mixed
     {
@@ -145,8 +146,8 @@ final class InputQuery implements InputQueryInterface
     }
 
     /**
-     * @param array<string, mixed> $query
-     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     * @param array<string, mixed>              $query
+     * @param array<ReflectionAttribute<Input>> $inputAttributes
      */
     private function resolveObjectType(ReflectionParameter $param, array $query, array $inputAttributes, ReflectionNamedType $type): mixed
     {
@@ -174,8 +175,8 @@ final class InputQuery implements InputQueryInterface
     }
 
     /**
-     * @param array<string, mixed> $query
-     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     * @param array<string, mixed>              $query
+     * @param array<ReflectionAttribute<Input>> $inputAttributes
      */
     private function resolveArrayObjectType(string $paramName, array $query, array $inputAttributes, string $className): mixed
     {
@@ -203,6 +204,7 @@ final class InputQuery implements InputQueryInterface
         assert(class_exists($className));
         /** @var class-string $className */
         $reflectionClass = new ReflectionClass($className);
+
         return $reflectionClass->newInstance($array);
     }
 
@@ -361,5 +363,4 @@ final class InputQuery implements InputQueryInterface
 
         return $result;
     }
-
 }

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -26,6 +26,7 @@ use function is_int;
 use function is_numeric;
 use function is_scalar;
 use function is_string;
+use function is_subclass_of;
 use function lcfirst;
 use function sprintf;
 use function str_replace;
@@ -118,8 +119,20 @@ final class InputQuery implements InputQueryInterface
             return $this->convertScalar($value, $type);
         }
 
-        // Check if it's ArrayObject with item specification
-        if ($type->getName() === 'ArrayObject') {
+        // Check if it's ArrayObject or its subclass with item specification
+        $className = $type->getName();
+        if (class_exists($className) && is_subclass_of($className, ArrayObject::class)) {
+            $inputAttribute = $inputAttributes[0]->newInstance();
+            if ($inputAttribute->item !== null) {
+                $array = $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);
+                $reflectionClass = new ReflectionClass($className);
+
+                return $reflectionClass->newInstance($array);
+            }
+        }
+
+        // Check if it's ArrayObject itself with item specification
+        if ($className === ArrayObject::class) {
             $inputAttribute = $inputAttributes[0]->newInstance();
             if ($inputAttribute->item !== null) {
                 $array = $this->createArrayOfInputs($paramName, $query, $inputAttribute->item);

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -323,4 +323,5 @@ final class InputQuery implements InputQueryInterface
 
         return $result;
     }
+
 }

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -21,6 +21,7 @@ use ReflectionParameter;
 use function array_key_exists;
 use function assert;
 use function class_exists;
+use function gettype;
 use function is_array;
 use function is_bool;
 use function is_float;
@@ -335,7 +336,7 @@ final class InputQuery implements InputQueryInterface
      * @param array<string, mixed> $query
      * @param class-string<T>      $itemClass
      *
-     * @return array<mixed>
+     * @return array<array-key, T>
      */
     private function createArrayOfInputs(string $paramName, array $query, string $itemClass): array
     {
@@ -353,12 +354,20 @@ final class InputQuery implements InputQueryInterface
         $result = [];
         /** @var mixed $itemData */
         foreach ($arrayData as $key => $itemData) {
-            if (is_array($itemData)) {
-                // Query parameters from HTTP requests have string keys
-                /** @psalm-var array<string, mixed> $itemData */
-                /** @phpstan-var array<string, mixed> $itemData */
-                $result[$key] = $this->create($itemClass, $itemData);
+            if (! is_array($itemData)) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Expected array for item at key "%s", got %s.',
+                        $key,
+                        gettype($itemData),
+                    ),
+                );
             }
+
+            // Query parameters from HTTP requests have string keys
+            /** @psalm-var array<string, mixed> $itemData */
+            /** @phpstan-var array<string, mixed> $itemData */
+            $result[$key] = $this->create($itemClass, $itemData);
         }
 
         return $result;

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -95,7 +95,15 @@ final class InputQuery implements InputQueryInterface
             return $this->resolveFromDI($param);
         }
 
-        // Has #[Input] attribute - get from query
+        return $this->resolveInputParameter($param, $query, $inputAttributes);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     */
+    private function resolveInputParameter(ReflectionParameter $param, array $query, array $inputAttributes): mixed
+    {
         $type = $param->getType();
         $paramName = $param->getName();
 
@@ -104,68 +112,98 @@ final class InputQuery implements InputQueryInterface
         }
 
         if ($type->isBuiltin()) {
-            // Check if it's an array type with item specification
-            if ($type->getName() === 'array') {
-                $inputAttribute = $inputAttributes[0]->newInstance();
-                if ($inputAttribute->item !== null) {
-                    assert(class_exists($inputAttribute->item));
-                    $itemClass = $inputAttribute->item;
-
-                    /** @var class-string<T> $itemClass */
-                    return $this->createArrayOfInputs($paramName, $query, $itemClass);
-                }
-            }
-
-            // Scalar type with #[Input]
-            /** @psalm-suppress MixedAssignment $value */
-
-            $value = $query[$paramName] ?? $this->getDefaultValue($param);
-
-            return $this->convertScalar($value, $type);
+            return $this->resolveBuiltinType($param, $query, $inputAttributes, $type);
         }
 
-        // Check if it's ArrayObject or its subclass with item specification
+        return $this->resolveObjectType($param, $query, $inputAttributes, $type);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     */
+    private function resolveBuiltinType(ReflectionParameter $param, array $query, array $inputAttributes, ReflectionNamedType $type): mixed
+    {
+        $paramName = $param->getName();
+
+        if ($type->getName() === 'array') {
+            $inputAttribute = $inputAttributes[0]->newInstance();
+            if ($inputAttribute->item !== null) {
+                assert(class_exists($inputAttribute->item));
+                $itemClass = $inputAttribute->item;
+
+                /** @var class-string<T> $itemClass */
+                return $this->createArrayOfInputs($paramName, $query, $itemClass);
+            }
+        }
+
+        // Scalar type with #[Input]
+        /** @psalm-suppress MixedAssignment $value */
+        $value = $query[$paramName] ?? $this->getDefaultValue($param);
+
+        return $this->convertScalar($value, $type);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     */
+    private function resolveObjectType(ReflectionParameter $param, array $query, array $inputAttributes, ReflectionNamedType $type): mixed
+    {
+        $paramName = $param->getName();
         $className = $type->getName();
-        if (class_exists($className) && is_subclass_of($className, ArrayObject::class)) {
-            $inputAttribute = $inputAttributes[0]->newInstance();
-            if ($inputAttribute->item !== null) {
-                assert(class_exists($inputAttribute->item));
-                /** @var class-string<T> $itemClass */
-                $itemClass = $inputAttribute->item;
-                $array = $this->createArrayOfInputs($paramName, $query, $itemClass);
-                $reflectionClass = new ReflectionClass($className);
 
-                return $reflectionClass->newInstance($array);
-            }
+        // Check for ArrayObject types with item specification
+        $arrayObjectResult = $this->resolveArrayObjectType($paramName, $query, $inputAttributes, $className);
+        if ($arrayObjectResult !== null) {
+            return $arrayObjectResult;
         }
 
-        // Check if it's ArrayObject itself with item specification
-        if ($className === ArrayObject::class) {
-            $inputAttribute = $inputAttributes[0]->newInstance();
-            if ($inputAttribute->item !== null) {
-                assert(class_exists($inputAttribute->item));
-                /** @var class-string<T> $itemClass */
-                $itemClass = $inputAttribute->item;
-                $array = $this->createArrayOfInputs($paramName, $query, $itemClass);
-
-                return new ArrayObject($array);
-            }
-        }
-
-        // Object type with #[Input] - create nested
+        // Regular object type with #[Input] - create nested
         $nestedQuery = $this->extractNestedQuery($paramName, $query);
 
         // If no nested keys found, try using the entire query
-        // This handles cases like controller method parameters
         if (empty($nestedQuery)) {
             $nestedQuery = $query;
         }
 
-        $class = $type->getName();
-        assert(class_exists($class));
+        assert(class_exists($className));
 
-        /** @var class-string<T> $class */
-        return $this->create($class, $nestedQuery);
+        /** @var class-string<T> $className */
+        return $this->create($className, $nestedQuery);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<\ReflectionAttribute<Input>> $inputAttributes
+     */
+    private function resolveArrayObjectType(string $paramName, array $query, array $inputAttributes, string $className): mixed
+    {
+        $isArrayObjectSubclass = class_exists($className) && is_subclass_of($className, ArrayObject::class);
+        $isArrayObject = $className === ArrayObject::class;
+
+        if (! $isArrayObjectSubclass && ! $isArrayObject) {
+            return null;
+        }
+
+        $inputAttribute = $inputAttributes[0]->newInstance();
+        if ($inputAttribute->item === null) {
+            return null;
+        }
+
+        assert(class_exists($inputAttribute->item));
+        /** @var class-string<T> $itemClass */
+        $itemClass = $inputAttribute->item;
+        $array = $this->createArrayOfInputs($paramName, $query, $itemClass);
+
+        if ($isArrayObject) {
+            return new ArrayObject($array);
+        }
+
+        assert(class_exists($className));
+        /** @var class-string $className */
+        $reflectionClass = new ReflectionClass($className);
+        return $reflectionClass->newInstance($array);
     }
 
     private function resolveFromDI(ReflectionParameter $param): mixed

--- a/tests/ArrayInputTest.php
+++ b/tests/ArrayInputTest.php
@@ -35,7 +35,6 @@ final class ArrayInputTest extends TestCase
         $controller = new class {
             /**
              * @param array<mixed> $users
-             * @param array<mixed>
              *
              * @return array<mixed>
              */
@@ -124,12 +123,12 @@ final class ArrayInputTest extends TestCase
     {
         $query = [];
 
-        /**
-         * @param array<mixed> $users
-         *
-         * @return array<mixed>
-         */
         $controller = new class {
+            /**
+             * @param array<mixed> $users
+             *
+             * @return array<mixed>
+             */
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
                 array $users,
@@ -155,6 +154,11 @@ final class ArrayInputTest extends TestCase
         $query = ['users' => 'not-an-array'];
 
         $controller = new class {
+            /**
+             * @param array<mixed> $users
+             *
+             * @return array<mixed>
+             */
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
                 array $users,
@@ -179,12 +183,12 @@ final class ArrayInputTest extends TestCase
             ],
         ];
 
-        /**
-         * @param array<mixed> $users
-         *
-         * @return array<mixed>
-         */
         $controller = new class {
+            /**
+             * @param array<mixed> $users
+             *
+             * @return array<mixed>
+             */
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
                 array $users,

--- a/tests/ArrayInputTest.php
+++ b/tests/ArrayInputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\InputQuery;
 
 use ArrayObject;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use Ray\InputQuery\Attribute\Input;
@@ -152,11 +153,8 @@ final class ArrayInputTest extends TestCase
     {
         $query = [
             'users' => [
-                'string-value',
-                123,
+                'string-value', // Non-array element at index 0
                 ['id' => '1', 'name' => 'valid'],
-                null,
-                true,
             ],
         ];
 
@@ -170,13 +168,11 @@ final class ArrayInputTest extends TestCase
         };
 
         $method = new ReflectionMethod($controller, 'listUsers');
-        $args = $this->inputQuery->getArguments($method, $query);
 
-        $this->assertIsArray($args[0]);
-        $this->assertCount(1, $args[0]); // Only the valid array element
-        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][2]);
-        $this->assertSame('1', $args[0][2]->id);
-        $this->assertSame('valid', $args[0][2]->name);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected array for item at key "0", got string.');
+
+        $this->inputQuery->getArguments($method, $query);
     }
 
     public function testCustomArrayObjectOfInputObjects(): void
@@ -215,5 +211,29 @@ final class ArrayInputTest extends TestCase
         $firstUser = $args[0]->getFirst();
         $this->assertInstanceOf(UserInputWithAttribute::class, $firstUser);
         $this->assertSame('5', $firstUser->id);
+    }
+
+    public function testArrayObjectWithoutItemAttribute(): void
+    {
+        $query = [
+            'users' => [
+                ['id' => '1', 'name' => 'test'],
+            ],
+        ];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input] // No item parameter specified
+                ArrayObject $users,
+            ): ArrayObject {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        // Should create a regular ArrayObject with the nested query data
+        $this->assertInstanceOf(ArrayObject::class, $args[0]);
     }
 }

--- a/tests/ArrayInputTest.php
+++ b/tests/ArrayInputTest.php
@@ -33,6 +33,12 @@ final class ArrayInputTest extends TestCase
         ];
 
         $controller = new class {
+            /**
+             * @param array<mixed> $users
+             * @param array<mixed>
+             *
+             * @return array<mixed>
+             */
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
                 array $users,
@@ -94,6 +100,11 @@ final class ArrayInputTest extends TestCase
         $query = ['users' => []];
 
         $controller = new class {
+            /**
+             * @param array<mixed> $users
+             *
+             * @return array<mixed>
+             */
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
                 array $users,
@@ -113,6 +124,11 @@ final class ArrayInputTest extends TestCase
     {
         $query = [];
 
+        /**
+         * @param array<mixed> $users
+         *
+         * @return array<mixed>
+         */
         $controller = new class {
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
@@ -131,6 +147,11 @@ final class ArrayInputTest extends TestCase
 
     public function testNonArrayValueForArrayParameter(): void
     {
+        /**
+         * @param array<mixed> $users
+         *
+         * @return array<mixed>
+         */
         $query = ['users' => 'not-an-array'];
 
         $controller = new class {
@@ -158,6 +179,11 @@ final class ArrayInputTest extends TestCase
             ],
         ];
 
+        /**
+         * @param array<mixed> $users
+         *
+         * @return array<mixed>
+         */
         $controller = new class {
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]
@@ -184,6 +210,11 @@ final class ArrayInputTest extends TestCase
             ],
         ];
 
+        /**
+         * @param array<mixed> $users
+         *
+         * @return array<mixed>
+         */
         $controller = new class {
             public function listUsers(
                 #[Input(item: UserInputWithAttribute::class)]

--- a/tests/ArrayInputTest.php
+++ b/tests/ArrayInputTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\InputQuery;
+
+use ArrayObject;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+use Ray\InputQuery\Attribute\Input;
+use Ray\InputQuery\Fake\CustomArrayObject;
+use Ray\InputQuery\Fake\UserInputWithAttribute;
+use ReflectionMethod;
+
+final class ArrayInputTest extends TestCase
+{
+    private InputQuery $inputQuery;
+
+    protected function setUp(): void
+    {
+        $injector = new Injector();
+        $this->inputQuery = new InputQuery($injector);
+    }
+
+    public function testArrayOfInputObjects(): void
+    {
+        $query = [
+            'users' => [
+                ['id' => '1', 'name' => 'jingu'],
+                ['id' => '2', 'name' => 'horikawa'],
+            ],
+        ];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                array $users,
+            ): array {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertIsArray($args[0]);
+        $this->assertCount(2, $args[0]);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][0]);
+        $this->assertSame('1', $args[0][0]->id);
+        $this->assertSame('jingu', $args[0][0]->name);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][1]);
+        $this->assertSame('2', $args[0][1]->id);
+        $this->assertSame('horikawa', $args[0][1]->name);
+    }
+
+    public function testArrayObjectOfInputObjects(): void
+    {
+        $query = [
+            'users' => [
+                ['id' => '3', 'name' => 'tanaka'],
+                ['id' => '4', 'name' => 'suzuki'],
+            ],
+        ];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                ArrayObject $users,
+            ): ArrayObject {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertInstanceOf(ArrayObject::class, $args[0]);
+        $this->assertCount(2, $args[0]);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][0]);
+        $this->assertSame('3', $args[0][0]->id);
+        $this->assertSame('tanaka', $args[0][0]->name);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][1]);
+        $this->assertSame('4', $args[0][1]->id);
+        $this->assertSame('suzuki', $args[0][1]->name);
+    }
+
+    public function testEmptyArray(): void
+    {
+        $query = ['users' => []];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                array $users,
+            ): array {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertIsArray($args[0]);
+        $this->assertCount(0, $args[0]);
+    }
+
+    public function testMissingArrayParameter(): void
+    {
+        $query = [];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                array $users,
+            ): array {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertIsArray($args[0]);
+        $this->assertCount(0, $args[0]);
+    }
+
+    public function testNonArrayValueForArrayParameter(): void
+    {
+        $query = ['users' => 'not-an-array'];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                array $users,
+            ): array {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertIsArray($args[0]);
+        $this->assertCount(0, $args[0]);
+    }
+
+    public function testArrayWithNonArrayElements(): void
+    {
+        $query = [
+            'users' => [
+                'string-value',
+                123,
+                ['id' => '1', 'name' => 'valid'],
+                null,
+                true,
+            ],
+        ];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                array $users,
+            ): array {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertIsArray($args[0]);
+        $this->assertCount(1, $args[0]); // Only the valid array element
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][2]);
+        $this->assertSame('1', $args[0][2]->id);
+        $this->assertSame('valid', $args[0][2]->name);
+    }
+
+    public function testCustomArrayObjectOfInputObjects(): void
+    {
+        $query = [
+            'users' => [
+                ['id' => '5', 'name' => 'yamada'],
+                ['id' => '6', 'name' => 'sato'],
+            ],
+        ];
+
+        $controller = new class {
+            public function listUsers(
+                #[Input(item: UserInputWithAttribute::class)]
+                CustomArrayObject $users,
+            ): CustomArrayObject {
+                return $users;
+            }
+        };
+
+        $method = new ReflectionMethod($controller, 'listUsers');
+        $args = $this->inputQuery->getArguments($method, $query);
+
+        $this->assertInstanceOf(CustomArrayObject::class, $args[0]);
+        $this->assertCount(2, $args[0]);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][0]);
+        $this->assertSame('5', $args[0][0]->id);
+        $this->assertSame('yamada', $args[0][0]->name);
+
+        $this->assertInstanceOf(UserInputWithAttribute::class, $args[0][1]);
+        $this->assertSame('6', $args[0][1]->id);
+        $this->assertSame('sato', $args[0][1]->name);
+
+        // Test custom method
+        $firstUser = $args[0]->getFirst();
+        $this->assertInstanceOf(UserInputWithAttribute::class, $firstUser);
+        $this->assertSame('5', $firstUser->id);
+    }
+}

--- a/tests/Fake/CustomArrayObject.php
+++ b/tests/Fake/CustomArrayObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\InputQuery\Fake;
+
+use ArrayObject;
+
+final class CustomArrayObject extends ArrayObject
+{
+    public function getFirst(): mixed
+    {
+        return $this[0] ?? null;
+    }
+}

--- a/tests/Fake/UserInput.php
+++ b/tests/Fake/UserInput.php
@@ -11,5 +11,6 @@ final class UserInput
     public function __construct(
         #[Input] public readonly string $name,
         #[Input] public readonly string $email
-    ) {}
+    ) {
+    }
 }

--- a/tests/Fake/UserInputWithAttribute.php
+++ b/tests/Fake/UserInputWithAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\InputQuery\Fake;
+
+use Ray\InputQuery\Attribute\Input;
+
+final class UserInputWithAttribute
+{
+    public function __construct(
+        #[Input]
+        public readonly string $id,
+        #[Input]
+        public readonly string $name
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

Add support for array and ArrayObject parameters to the Input attribute system, allowing automatic conversion of array data to collections of Input objects.

## Features

- **Array Support**: Use `#[Input(item: UserInput::class)]` with `array` type parameters
- **ArrayObject Support**: Use `#[Input(item: UserInput::class)]` with `ArrayObject` type parameters  
- **ArrayObject Inheritance**: Support for custom ArrayObject subclasses
- **Type Safety**: Full PHPStan and Psalm compatibility with proper type annotations
- **Edge Case Handling**: Robust handling of non-array data and invalid array elements

## Example Usage

```php
final class UserInput
{
    public function __construct(
        #[Input] public readonly string $id,
        #[Input] public readonly string $name
    ) {}
}

final class UserController
{
    public function updateUsers(
        #[Input(item: UserInput::class)] array $users
    ) {
        foreach ($users as $user) {
            echo $user->name; // Each element is a UserInput instance
        }
    }
}
```

## Query Data Format

```php
$data = [
    'users' => [
        ['id' => '1', 'name' => 'John'],
        ['id' => '2', 'name' => 'Jane']
    ]
];
```

## Test Coverage

- ✅ 100% code coverage maintained
- ✅ Array parameter handling
- ✅ ArrayObject parameter handling  
- ✅ Custom ArrayObject inheritance
- ✅ Edge cases (empty arrays, non-array data, invalid elements)
- ✅ Static analysis (PHPStan + Psalm) passes

## Documentation

- Updated README.md with comprehensive array support documentation
- Added examples for basic usage and ArrayObject inheritance
- Documented query data format requirements

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add support for mapping query arrays and `ArrayObject` instances into collections of `Input`-decorated objects by introducing an `item` parameter on the `Input` attribute and updating the parsing logic accordingly.

New Features:
- Support array parameters with `#[Input(item: …)]` to produce collections of Input objects
- Support `ArrayObject` parameters (including subclasses) with `#[Input(item: …)]` to produce collections of Input objects

Enhancements:
- Introduce `createArrayOfInputs` helper and extend `resolveParameter` to handle arrays and `ArrayObject` inheritance
- Extend `Input` attribute to accept an optional `item` class parameter for collection typing

Documentation:
- Update README with array and `ArrayObject` support documentation and usage examples

Tests:
- Add comprehensive tests for array inputs, `ArrayObject` inputs, empty/missing/invalid data cases, and custom `ArrayObject` subclasses

Chores:
- Add demo script showcasing array and `ArrayObject` usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automatically mapping arrays and ArrayObject collections of input objects using the `item` parameter in the input attribute.
  * Enhanced input handling to support custom ArrayObject subclasses for input collections.
  * Introduced new demo and documentation examples illustrating array and collection input scenarios.
  * Extended allowed Bash command permissions to include PHPUnit and PHP Mess Detector commands.

* **Documentation**
  * Expanded the README with a new section explaining array and ArrayObject input support, usage examples, and expected input formats.

* **Tests**
  * Added comprehensive tests for array and collection input handling, including edge cases and custom collection classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->