### PR TITLE
Support bracket object

### DIFF
--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -265,7 +265,8 @@ final class InputQuery implements InputQueryInterface
 
         // Check if the parameter name exists as a direct nested array in query
         if (array_key_exists($paramName, $query) && is_array($query[$paramName])) {
-            assert(class_exists($className));
+            // This should never fail as $className comes from ReflectionParameter type info
+            assert(class_exists($className), "Internal logic error: Class '$className' from reflection should exist");
 
             /** @var Query $nestedQuery */
             $nestedQuery = $query[$paramName];

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -266,7 +266,7 @@ final class InputQuery implements InputQueryInterface
         // Check if the parameter name exists as a direct nested array in query
         if (array_key_exists($paramName, $query) && is_array($query[$paramName])) {
             assert(class_exists($className));
-            /** @var class-string<T> $className */
+
             return $this->newInstance($className, $query[$paramName]);
         }
 

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -263,6 +263,13 @@ final class InputQuery implements InputQueryInterface
             return $arrayObjectResult;
         }
 
+        // Check if the parameter name exists as a direct nested array in query
+        if (array_key_exists($paramName, $query) && is_array($query[$paramName])) {
+            assert(class_exists($className));
+            /** @var class-string<T> $className */
+            return $this->newInstance($className, $query[$paramName]);
+        }
+
         // Regular object type with #[Input] - create nested
         $nestedQuery = $this->extractNestedQuery($paramName, $query);
 

--- a/src/InputQuery.php
+++ b/src/InputQuery.php
@@ -267,7 +267,11 @@ final class InputQuery implements InputQueryInterface
         if (array_key_exists($paramName, $query) && is_array($query[$paramName])) {
             assert(class_exists($className));
 
-            return $this->newInstance($className, $query[$paramName]);
+            /** @var Query $nestedQuery */
+            $nestedQuery = $query[$paramName];
+
+            /** @var class-string<T> $className */
+            return $this->newInstance($className, $nestedQuery);
         }
 
         // Regular object type with #[Input] - create nested

--- a/tests/InputQueryTest.php
+++ b/tests/InputQueryTest.php
@@ -118,6 +118,26 @@ final class InputQueryTest extends TestCase
         $this->assertSame('john@example.com', $todo->author->email);
     }
 
+    public function testCreateBracketObject(): void
+    {
+        $query = [
+            'title' => 'Buy milk',
+            'author' => [
+                'name' => 'John',
+                'email' => 'john@example.com',
+            ],
+        ];
+
+        $todo = $this->inputQuery->newInstance(TodoInput::class, $query);
+
+        $this->assertInstanceOf(TodoInput::class, $todo);
+        /** @var TodoInput $todo */
+        $this->assertSame('Buy milk', $todo->title);
+        $this->assertInstanceOf(AuthorInput::class, $todo->author);
+        $this->assertSame('John', $todo->author->name);
+        $this->assertSame('john@example.com', $todo->author->email);
+    }
+
     public function testCreateMixedInputAndDI(): void
     {
         $query = [


### PR DESCRIPTION
`author` のようにネストしたデータ形式の対応

```html
<form method="post">
<input type="text" name="title" value="Buy milk">
<input type="text" name="author[name]" value="John">
<input type="text" name="author[email]" value="john@example.com">
</form>
```

```php
[
  'title' => 'Buy milk',
  'author' => [
    'name' => 'John',
    'email' => 'john@example.com',
  ],
]
```

## Summary by Sourcery

Add support for bracket object notation in InputQuery to create nested input objects from direct nested arrays and include a corresponding unit test.

New Features:
- Support instantiating nested input objects from direct array entries keyed by the parameter name

Tests:
- Add testCreateBracketObject to verify bracket notation object instantiation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for nested associative arrays in input queries, allowing for direct object creation from nested structures.

* **Tests**
  * Added a new test to verify correct handling and instantiation of objects from nested associative array inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->